### PR TITLE
delete knative services/v1 crd

### DIFF
--- a/src/playbooks/cleanup-all-rhoai-kserve/config.yaml
+++ b/src/playbooks/cleanup-all-rhoai-kserve/config.yaml
@@ -103,8 +103,12 @@ playbook:
 
             oc delete csv OperatorGroup serverless-operators -n openshift-serverless                                               %%
 
+            # delete crds %%
+            oc delete crd services.serving.knative.dev                                                                             %%
+            
             # InstallPlan %%
             for installplan in $(oc get installPlan -n openshift-operators|grep -E 'authorino|serverless|servicemeshoperator|opendatahub|pipeline'|awk '{print $1}')
             do  
                oc delete installPlan -n openshift-operators $installplan
-            done 
+            done
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced cleanup functionality by adding a command to delete Custom Resource Definitions (CRDs) for Knative services.
  
- **Style**
	- Improved readability with minor formatting adjustments in the cleanup script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->