### PR TITLE
Kind role

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,30 +1,44 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Python Debugger: Current File",
-      "type": "debugpy",
-      "request": "launch",
-      "program": "${workspaceFolder}/loopy.py",
-      "console": "integratedTerminal",
-      "env": { "PYTHONPATH": "src" },
-      // "args": ["roles", "run", "shell-execute", "-p", "COMMANDS=echo test"]
-      "args": ["playbooks", "run", "loopy-unit-tests", "-g"]
-      // "args": ["units", "run", "loopy-roles-test-non-cluster-shell-execute"]
-    },
-
-    {
-      "name": "Attach to Loopy",
-      "type": "debugpy",
-      "request": "attach",
-      "connect": {
-        "host": "localhost",
-        "port": 5678
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Launch Package",
+        "type": "go",
+        "request": "launch",
+        "mode": "auto",
+        "program": "${fileDirname}",
+        "env": {
+          "POD_NAMESPACE": "kserve"
+        }
       },
-      "justMyCode": false
-    }
-  ]
-}
+      {
+        "name": "Debug Ginkgo Test(inferenceservice)",
+        "type": "go",
+        "request": "launch",
+        "mode": "auto",
+        "program": "${workspaceFolder}/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go",
+        "args": [
+        "-ginkgo.v",
+        "-ginkgo.focus", "When creating inference service with raw kube predictor with workerSpec"
+        ],
+        "env": {
+          "KUBEBUILDER_ASSETS": "/home/jooho/.local/share/kubebuilder-envtest/k8s/1.29.5-linux-amd64"
+        }
+      },
+      {
+        "name": "Debug Ginkgo Test(inferenceGraph)",
+        "type": "go",
+        "request": "launch",
+        "mode": "auto",
+        "program": "${workspaceFolder}/pkg/controller/v1alpha1/inferencegraph/",
+        "args": ["-ginkgo.v"],
+        "env": {
+          "KUBEBUILDER_ASSETS": "/home/jooho/.local/share/kubebuilder-envtest/k8s/1.29.5-linux-amd64"
+        }
+      }
+    ]
+  }
+  

--- a/hacks/download-cli.sh
+++ b/hacks/download-cli.sh
@@ -169,6 +169,15 @@ if [[ $TEST_ENV == "local" ]]; then
       mv ocm "${root_directory}/bin/ocm"
       echo "✅ OCM CLI installed successfully!"
   fi
+  # Install kind
+  if ! check_binary_exists "${root_directory}/bin/kind"; then
+      echo "⬇️ Downloading kind (Latest)..."
+      wget --progress=bar:force:noscroll "https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64" -O kind
+      chmod +x kind
+      rm -rf "${root_directory}/bin/kind"
+      mv kind "${root_directory}/bin/kind"
+      echo "✅ kind installed successfully!"
+  fi
 fi
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,14 +15,12 @@ markers =
   cli_report: loopy report
 
   fvt: loopy fvt tests - test main.py or main.sh
-  fvt_test: loopy fvt tests - test main.py or main.sh
   fvt_roles: loopy fvt roles tests
   fvt_units: loopy fvt units tests
   fvt_playbooks: loopy fvt playbooks tests
   
   
   e2e: loopy e2e tests
-  e2e_test: loopy e2e tests
   e2e_roles: loopy e2e roles tests
   e2e_units: loopy e2e units tests
   e2e_playbooks: loopy e2e playbooks tests
@@ -31,6 +29,7 @@ markers =
 
   cluster_tests: tests needs a cluster(run)
   non_cluster_tests: tests does not need a cluster(run)
+  cluster_life_cycle_tests: tests for cluster life cycle
     
 filterwarnings =
     ignore::pytest.PytestCollectionWarning    

--- a/src/commons/scripts/utils.sh
+++ b/src/commons/scripts/utils.sh
@@ -511,3 +511,25 @@ validate_script_params() {
     
     return 0
 } 
+
+# retry function
+# Usage: retry <max_attempts> <sleep_seconds> <command> <message>
+# Example: retry 120 5 "! kind get clusters | grep -q '^${KIND_CLUSTER_NAME}$'" "Waiting for cluster ${KIND_CLUSTER_NAME} to be fully deleted"
+retry() {
+    local max_attempts=$1
+    local sleep_seconds=$2
+    local command=$3
+    local message=$4
+    local attempt=1
+
+    until eval "$command"; do
+        if ((attempt == max_attempts)); then
+            echo "Failed after $max_attempts attempts: $message"
+            return 1
+        fi
+        echo "Attempt $attempt/$max_attempts: $message"
+        sleep "$sleep_seconds"
+        ((attempt++))
+    done
+    return 0
+} 

--- a/src/roles/kind/__init__.py
+++ b/src/roles/kind/__init__.py
@@ -1,0 +1,1 @@
+"""Kind role package."""

--- a/src/roles/kind/install/__init__.py
+++ b/src/roles/kind/install/__init__.py
@@ -1,0 +1,1 @@
+"""Kind install package."""

--- a/src/roles/kind/install/config.yaml
+++ b/src/roles/kind/install/config.yaml
@@ -1,0 +1,61 @@
+role:
+  created_date: "20250602"
+  name: kind-install
+  files:
+    kind-ingress-config: ./files/kind-ingress-config.yaml
+  description: |
+    This role help to create a kind cluster with a nginx ingress controller/olm operator.
+
+    pre-requirements:
+      Docker/Podman installed   
+
+    Input Environment:
+      The parameters include:
+      - NGINX_INGRESS_VERSION: Set NGINX_INGRESS_VERSION (default: v1.10.1)
+      - CONTAINER_RUNTIME: Set CONTAINER_RUNTIME (docker/podman) (default: docker)
+
+    To run it:
+    ./loopy roles run create-kind-cluster  \
+    -p CONTAINER_RUNTIME=docker \
+    -p NGINX_INGRESS_VERSION=v1.10.1 \
+    -p ENABLE_INGRESS="true" \
+    -p ENABLE_OLM="true" \
+    -p OLM_VERSION=v0.18.3 \
+    -p KUBECONFIG_PATH=~/.kube/config \
+    -p KIND_CLUSTER_NAME=kind
+
+
+  input_env:
+  - name: KUBECONFIG_PATH
+    description: |
+      Set KUBECONFIG_PATH (default: ~/.kube/config)
+    default: ~/.kube/config
+  - name: KIND_CLUSTER_NAME
+    description: |
+      Set KIND_CLUSTER_NAME (default: kind)
+    default: kind
+  - name: ENABLE_INGRESS
+    description: |
+      Set ENABLE_INGRESS (true/false)
+    default: "true"
+  - name: NGINX_INGRESS_VERSION
+    description: |
+      Set NGINX_INGRESS_VERSION (default: 1.10.1)
+    default: 1.10.1
+  - name: ENABLE_OLM
+    description: |
+      Set ENABLE_OLM (true/false)
+    default: "true"
+  - name: OLM_VERSION
+    description: |
+      Set OLM_VERSION (default: v0.18.3)
+    default: v0.18.3
+  - name: CONTAINER_RUNTIME
+    description: |
+      Set CONTAINER_RUNTIME (docker/podman)
+    default: docker
+
+  output_env:
+  - name: KUBECONFIG_PATH
+    description: This shows the path where the kubeconfig file will be saved
+    required: true

--- a/src/roles/kind/install/files/kind-ingress-config.yaml
+++ b/src/roles/kind/install/files/kind-ingress-config.yaml
@@ -1,0 +1,10 @@
+# kind-ingress-config.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 80   # Ingress HTTP
+        hostPort: 80
+      - containerPort: 443  # Ingress HTTPS
+        hostPort: 443

--- a/src/roles/kind/install/main.sh
+++ b/src/roles/kind/install/main.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+## INIT START ##
+if [[ $DEBUG == "0" ]]; then
+  set -x
+fi
+
+# Get the directory where this script is located
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Traverse up the directory tree to find the .github folder
+github_dir="$current_dir"
+while [ ! -d "$github_dir/.git" ] && [ "$github_dir" != "/" ]; do
+  github_dir="$(dirname "$github_dir")"
+done
+
+# If the .github folder is found, set root_directory
+if [ -d "$github_dir/.git" ]; then
+  root_directory="$github_dir"
+  echo "The root directory is: $root_directory"
+else
+  echo "Unable to find .github folder"
+fi
+## INIT END ##
+
+#################################################################
+source $root_directory/src/commons/scripts/utils.sh
+index_role_name=$(basename $ROLE_DIR)
+role_name=$(yq e '.role.name' ${current_dir}/config.yaml)
+kind_ingress_config=$(yq e '.role.files.kind-ingress-config' $current_dir/config.yaml)
+kind_ingress_config_path=$current_dir/$kind_ingress_config
+
+
+# Check if docker/podman is installed
+if ! command -v $CONTAINER_RUNTIME &> /dev/null; then
+  fatal "docker/podman could not be found"
+fi
+
+# Check if kind is installed
+if ! command -v kind &> /dev/null; then
+  fatal "kind could not be found: try make download-cli"  
+fi
+
+kind_options=""
+if [[ $(is_positive ${ENABLE_INGRESS}) == "0" ]]; then
+  kind_options+=" --config=$kind_ingress_config_path"
+fi
+
+# Create kind cluster
+if kind get clusters | grep -q "^${KIND_CLUSTER_NAME}$"; then
+  info "Kind cluster ${KIND_CLUSTER_NAME} already exists, skipping creation"
+else
+  info "Creating kind cluster with ingress config"  
+  kind create cluster --name "$KIND_CLUSTER_NAME" $kind_options
+fi
+
+if [[ $(is_positive ${ENABLE_INGRESS}) == "0" ]]; then  
+  info "Installing nginx ingress controller"
+  kubectl label node/${KIND_CLUSTER_NAME}-control-plane ingress-ready=true --overwrite
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v${NGINX_INGRESS_VERSION}/deploy/static/provider/kind/deploy.yaml
+fi
+
+# Install OLM
+if [[ $(is_positive ${ENABLE_OLM}) == "0" ]]; then
+  info "Installing OLM"
+  curl -sL https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/refs/heads/master/deploy/upstream/quickstart/install.sh | bash -s $OLM_VERSION
+fi
+
+
+############# VERIFY #############
+result=0
+
+# Verify kind cluster is running
+if ! retry 60 5 "kubectl cluster-info &>/dev/null" "Waiting for kind cluster to be ready"; then
+    fail "Kind cluster is not running properly after 5 minutes"
+    result=1
+else
+    success "Kind cluster is running properly"
+fi
+
+# Verify ingress if enabled
+if [[ $(is_positive ${ENABLE_INGRESS}) == "0" ]]; then
+    if ! retry 60 5 "kubectl get pods -n ingress-nginx -l app.kubernetes.io/component=controller &>/dev/null" "Waiting for ingress controller to be ready"; then
+        fail "Ingress controller is not running properly after 5 minutes"
+        result=1
+    else
+        success "Ingress controller is running properly"
+    fi
+fi
+
+# Verify OLM if enabled
+if [[ $(is_positive ${ENABLE_OLM}) == "0" ]]; then
+    if ! retry 60 5 "kubectl get pods -n olm -l app=olm-operator &>/dev/null" "Waiting for OLM operator to be ready"; then
+        fail "OLM operator is not running properly after 5 minutes"
+        result=1
+    else
+        success "OLM operator is running properly"
+    fi
+fi
+
+############# OUTPUT #############
+if [[ $result -eq 0 ]]; then
+    # Get the kind kubeconfig path
+    if [[ ${KUBECONFIG_PATH} != '~/.kube/config' ]]; then
+      kind get kubeconfig --name ${KIND_CLUSTER_NAME} > ${KUBECONFIG_PATH}
+    fi
+    # Write to output environment file
+    info "Writing environment variables to output file"    
+    echo "KUBECONFIG_PATH=${KUBECONFIG_PATH}" >>${OUTPUT_ENV_FILE}
+fi
+
+############# REPORT #############
+echo "${index_role_name}::${result}" >>${REPORT_FILE}

--- a/src/roles/kind/uninstall/__init__.py
+++ b/src/roles/kind/uninstall/__init__.py
@@ -1,0 +1,1 @@
+"""Kind uninstall package."""

--- a/src/roles/kind/uninstall/config.yaml
+++ b/src/roles/kind/uninstall/config.yaml
@@ -1,0 +1,22 @@
+role:
+  created_date: "20250602"
+  name: kind-uninstall
+  description: |
+    This role helps to uninstall a kind cluster and clean up related resources.
+
+    pre-requirements:
+      - kind CLI installed
+      - Docker/Podman installed
+
+    Input Environment:
+      The parameters include:
+      - KIND_CLUSTER_NAME: Name of the kind cluster to delete (default: kind)
+
+    To run it:
+    ./loopy roles run kind-uninstall \
+    -p KIND_CLUSTER_NAME=my-cluster
+
+  input_env:
+  - name: KIND_CLUSTER_NAME
+    description: Name of the kind cluster to delete
+    default: kind

--- a/src/roles/kind/uninstall/main.sh
+++ b/src/roles/kind/uninstall/main.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+## INIT START ##
+if [[ $DEBUG == "0" ]]; then
+  set -x
+fi
+
+# Get the directory where this script is located
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Traverse up the directory tree to find the .github folder
+github_dir="$current_dir"
+while [ ! -d "$github_dir/.git" ] && [ "$github_dir" != "/" ]; do
+  github_dir="$(dirname "$github_dir")"
+done
+
+# If the .github folder is found, set root_directory
+if [ -d "$github_dir/.git" ]; then
+  root_directory="$github_dir"
+  echo "The root directory is: $root_directory"
+else
+  echo "Error: Unable to find .github folder."
+fi
+source $root_directory/src/commons/scripts/utils.sh
+## INIT END ##
+
+#################################################################
+# Get role information from config
+index_role_name=$(basename $ROLE_DIR)
+role_name=$(yq e '.role.name' ${current_dir}/config.yaml)
+
+# Check if kind is installed
+if ! command -v kind &> /dev/null; then
+  fatal "kind could not be found: try make download-cli"  
+fi
+
+############# UNINSTALL #############
+# Initialize result variable to track success/failure
+result=0
+
+# Check if cluster exists before attempting deletion
+if ! kind get clusters | grep -q "^${KIND_CLUSTER_NAME}$"; then
+    info "Kind cluster ${KIND_CLUSTER_NAME} does not exist"
+    result=0  # Not an error if cluster doesn't exist
+else
+    # Delete the kind cluster if it exists
+    if ! kind delete cluster --name ${KIND_CLUSTER_NAME}; then
+        fail "Failed to delete kind cluster ${KIND_CLUSTER_NAME}"
+        result=1
+    else
+        success "Successfully deleted kind cluster ${KIND_CLUSTER_NAME}"
+    fi
+fi
+
+############# VERIFY #############
+# Verify that the cluster is actually deleted
+# Retry checking cluster deletion for up to 2 minutes (120 seconds) with 5 second intervals
+if ! retry 120 5 "! kind get clusters | grep -q '^${KIND_CLUSTER_NAME}$'" "Waiting for cluster ${KIND_CLUSTER_NAME} to be fully deleted"; then
+    fail "Kind cluster ${KIND_CLUSTER_NAME} still exists after 2 minutes"
+    result=1
+fi
+
+############# REPORT #############
+# Write the result to the report file in the format "role_name::result"
+echo "${index_role_name}::${result}" >>${REPORT_FILE} 

--- a/tests/e2e/cluster-life-cycle/kind_install_delete/conftest.py
+++ b/tests/e2e/cluster-life-cycle/kind_install_delete/conftest.py
@@ -1,0 +1,62 @@
+import os
+import pytest
+import yaml
+from pathlib import Path
+import subprocess
+import uuid
+
+
+@pytest.fixture(scope="session")
+def base_env():
+    """Fixture providing base environment variables needed for all tests"""
+    return {
+        "SHOW_DEBUG_LOG": "false",
+        "STOP_WHEN_FAILED": "false",
+        "STOP_WHEN_ERROR_HAPPENED": "false",
+        "ENABLE_LOOPY_LOG": "false",
+        "USE_KIND": "true",
+        "CLUSTER_API_URL": "",
+        "CLUSTER_ADMIN_ID": "",
+        "CLUSTER_ADMIN_PW": "",
+        "OUTPUT_ROOT_DIR": "/tmp/e2e_loopy_result",
+        "OUTPUT_TARGET_DIR": str(uuid.uuid4()),
+    }
+
+
+@pytest.fixture()
+def role_env(base_env):
+    """Fixture providing base environment variables needed for all tests"""
+    base_env["KIND_CLUSTER_NAME"] = "kind"
+    base_env["ENABLE_INGRESS"] = "0"  # 0 means true in the role
+    base_env["ENABLE_OLM"] = "0"  # 1 means false in the role
+    base_env["NGINX_INGRESS_VERSION"] = "1.10.1"
+    base_env["OLM_VERSION"] = "v0.26.0"
+    return base_env
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup(base_env):
+    yield
+    # List of cleanup commands to execute
+    cleanup_commands = [
+        f"kind delete cluster --name {base_env['KIND_CLUSTER_NAME']}",
+    ]
+
+    # Execute each command and check its result
+    for cmd in cleanup_commands:
+        result = subprocess.run(cmd, capture_output=True, text=True, shell=True)
+        if result.returncode != 0:
+            print(f"Warning: Cleanup command failed: {cmd}")
+            print(f"Error output: {result.stderr}")
+        else:
+            print(f"Successfully executed: {cmd}")
+
+    # Clean up output directory
+    output_root_dir = Path(base_env["OUTPUT_ROOT_DIR"]) / base_env["OUTPUT_TARGET_DIR"]
+    if output_root_dir.exists():
+        try:
+            import shutil
+
+            shutil.rmtree(output_root_dir)
+        except Exception as e:
+            print(f"Warning: Failed to clean up output directory: {e}")

--- a/tests/e2e/cluster-life-cycle/kind_install_delete/test_kind.py
+++ b/tests/e2e/cluster-life-cycle/kind_install_delete/test_kind.py
@@ -1,0 +1,91 @@
+import pytest
+import subprocess
+import os
+
+"""Test cases for the kind role."""
+
+
+@pytest.mark.e2e
+@pytest.mark.e2e_roles
+@pytest.mark.cluster_life_cycle_tests
+@pytest.mark.order(1)
+def test_kind_cluster_creation(role_env):
+    """Test kind cluster creation with ingress enabled."""
+    # Create a copy of the environment with PATH
+    env = os.environ.copy()
+    env.update(role_env)
+
+    # Run the role
+    result = subprocess.run(
+        [
+            "./loopy",
+            "roles",
+            "run",
+            "kind-install",
+            "-l",
+            "-g",
+            "-r",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, f"Command failed: {result.stderr}"
+
+    # Verify cluster exists
+    clusters = subprocess.check_output(["kind", "get", "clusters"]).decode().strip()
+    assert f"{role_env['KIND_CLUSTER_NAME']}" in clusters, "Cluster was not created"
+
+    # Verify ingress controller if enabled
+    if role_env["ENABLE_INGRESS"] == "0":
+        pods = subprocess.check_output(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "ingress-nginx",
+                "-l",
+                "app.kubernetes.io/component=controller",
+            ]
+        ).decode()
+        assert "Running" in pods, "Ingress controller is not running"
+
+    # Verify OLM if enabled
+    if role_env["ENABLE_OLM"] == "0":
+        pods = subprocess.check_output(
+            ["kubectl", "get", "pods", "-n", "olm", "-l", "app=olm-operator"]
+        ).decode()
+        assert "Running" in pods, "OLM operator is not running"
+
+
+@pytest.mark.e2e
+@pytest.mark.e2e_roles
+@pytest.mark.cluster_life_cycle_tests
+@pytest.mark.order(1)
+def test_kind_cluster_deletion(role_env):
+    """Test kind cluster deletion."""
+    # Create a copy of the environment with PATH
+    env = os.environ.copy()
+    env.update(role_env)
+
+    # Run the uninstall role
+    result = subprocess.run(
+        [
+            "./loopy",
+            "roles",
+            "run",
+            "kind-uninstall",
+            "-l",
+            "-g",
+            "-r",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, f"Command failed: {result.stderr}"
+
+    # Verify cluster is deleted
+    clusters = subprocess.check_output(["kind", "get", "clusters"]).decode().strip()
+    assert "test-cluster" not in clusters, "Cluster was not deleted"


### PR DESCRIPTION
Creating a kind cluster is the first requirement for testing upstream KServe. To streamline this process and avoid individual setup overhead for each team member, we should provide a dedicated Loopy role that automates the creation of a kind cluster.

This role will allow developers to easily provision a local Kubernetes environment tailored for KServe testing without worrying about the underlying setup steps.

